### PR TITLE
Create advertising_indication.yml

### DIFF
--- a/presets/advertising_indication.yml
+++ b/presets/advertising_indication.yml
@@ -1,9 +1,9 @@
 --- 
 author: PaDe
 description: 
-  default: "Pour participer à l'inventaire des préenseignes publicitaires en France, qui sont presque à 100% illégales."
-  en: "To participate in inventorying advertising indication boards in France, which are almost 100% unlawfull."
-  fr: "Pour participer à l'inventaire des préenseignes publicitaires en France, qui sont presque à 100% illégales."
+  default: "Pour participer à l'inventaire des préenseignes publicitaires en France, et recenser celles qui sont illégales."
+  en: "To participate in the creation of the inventory for advertising indicator boards, in France."
+  fr: "Pour participer à l'inventaire des préenseignes publicitaires en France, et recenser celles qui sont illégales."
 groups: 
   - 
     icon: "https://wiki.openstreetmap.org/wiki/File:Indication.svg"
@@ -34,19 +34,19 @@ groups:
               type: TAG
         description: 
           default: "Une préenseigne publicitaire, dispositif publicitaire hors-agglomération, pour présignaliser une activité."
-          en: "An indication board, found along a rural road, to advertise proximity of a craft/commercial/industrial activity. Rural advertising board."
+          en: "An indicator board found along a rural road, which advertises the proximity of a craft/commercial/industrial activity."
           fr: "Une préenseigne publicitaire, dispositif publicitaire hors-agglomération, pour présignaliser une activité."
         icon: "https://wiki.openstreetmap.org/wiki/File:Indication.svg"
         keywords: 
           default: 
             - "préenseigne publicité"
           en: 
-            - "advertising indication board"
+            - "advertising indicator board"
           fr: 
             - "préenseigne publicité"
         label: 
           default: "Préenseigne publicitaire"
-          en: "Advertising indication board"
+          en: "Advertising indicator board"
           fr: "Préenseigne publicitaire"
         name: advertising=board
         query: "node['advertising'='board']['legal_type:FR'='préenseigne']({{bbox}});out meta;out meta center;"
@@ -112,3 +112,4 @@ name:
   en: "Advertising indication board"
   fr: "Préenseigne publicitaire"
 version: "0.1"
+

--- a/presets/advertising_indication.yml
+++ b/presets/advertising_indication.yml
@@ -1,0 +1,114 @@
+--- 
+author: PaDe
+description: 
+  default: "Pour participer à l'inventaire des préenseignes publicitaires en France, qui sont presque à 100% illégales."
+  en: "To participate in inventorying advertising indication boards in France, which are almost 100% unlawfull."
+  fr: "Pour participer à l'inventaire des préenseignes publicitaires en France, qui sont presque à 100% illégales."
+groups: 
+  - 
+    icon: "https://wiki.openstreetmap.org/wiki/File:Indication.svg"
+    items: 
+      - 
+        constraints: 
+          - 
+            action: 
+              key: "legal_status:FR"
+              type: SET_TAG_VALUE
+              value: illégal
+            condition: 
+              type: EQUALS
+              value: autres
+            source: 
+              key: message
+              type: TAG
+          - 
+            action: 
+              key: "legal_type:FR"
+              type: SET_TAG_VALUE
+              value: publicité
+            condition: 
+              type: EQUALS
+              value: autres
+            source: 
+              key: message
+              type: TAG
+        description: 
+          default: "Une préenseigne publicitaire, dispositif publicitaire hors-agglomération, pour présignaliser une activité."
+          en: "An indication board, found along a rural road, to advertise proximity of a craft/commercial/industrial activity. Rural advertising board."
+          fr: "Une préenseigne publicitaire, dispositif publicitaire hors-agglomération, pour présignaliser une activité."
+        icon: "https://wiki.openstreetmap.org/wiki/File:Indication.svg"
+        keywords: 
+          default: 
+            - "préenseigne publicité"
+          en: 
+            - "advertising indication board"
+          fr: 
+            - "préenseigne publicité"
+        label: 
+          default: "Préenseigne publicitaire"
+          en: "Advertising indication board"
+          fr: "Préenseigne publicitaire"
+        name: advertising=board
+        query: "node['advertising'='board']['legal_type:FR'='préenseigne']({{bbox}});out meta;out meta center;"
+        tags: 
+          - 
+            key: advertising
+            type: CONSTANT
+            value: board
+          - 
+            key: support
+            type: CONSTANT
+            value: post
+          - 
+            key: man_made
+            type: CONSTANT
+            value: advertising
+          - 
+            key: size
+            type: CONSTANT
+            value: 1*1.5
+          - 
+            key: operator
+            required: false
+            type: TEXT
+          - 
+            key: land_property
+            type: SINGLE_CHOICE
+            values: 
+              - private
+              - public
+          - 
+            key: message
+            type: SINGLE_CHOICE
+            values: 
+              - terroir
+              - "monument historique"
+              - culturel
+              - "exceptionnel & temporaire"
+              - autres
+          - 
+            key: "legal_status:FR"
+            type: SINGLE_CHOICE
+            values: 
+              - légal
+              - "à vérifier"
+              - illégal
+          - 
+            key: "legal_type:FR"
+            type: SINGLE_CHOICE
+            values: 
+              - publicité
+              - préenseigne
+        url: "https://wiki.openstreetmap.org/wiki/FR:Tag:advertising%3Dboard"
+    name: 
+      default: Publicité
+      en: Advertising
+      fr: Publicité
+    url: "https://wiki.openstreetmap.org/wiki/Category:Advertising"
+image: "https://wiki.openstreetmap.org/wiki/File:Indication.svg"
+link: "https://github.com/jawg/h2geo-presets"
+name: 
+  default: "Préenseigne publicitaire"
+  en: "Advertising indication board"
+  fr: "Préenseigne publicitaire"
+version: "0.1"


### PR DESCRIPTION
#Profil OSM contributor pour renseigner les dispositifs publicitaires de type 'pré-enseigne'.

**Préenseigne publicitaire** : **seul** type de publicité autorisé en France **hors-agglomération**.
Dispositif publicitaire très réglementé en France, pour présignaliser une activité, avec en général une indication de direction et/ou de distance. Se différencie de l'enseigne par le fait qu'elle se situe en dehors du fonds où s'exerce l'activité. La taille est réglementée : 1,5 m de large sur 1 m de haut. En général au bord des routes rurales.
Depuis la loi ENE (12/07/2010) et après un délai de 5 ans de mise en conformité, donc depuis le 15 juillet 2015, seuls 4 types d'activités peuvent encore utiliser ces dispositifs :
 *Fabrication et vente de produits du terroir par des entreprises locales.
 *Activité culturelle (voir lesquelles).
 *Monuments historiques ouverts à la visite.
 *Certaines activités exceptionnelles temporaires.
La présignalisation hors-agglomération pour
 *Station service
 *Garage
 *Hôtel
 *Restaurant
 *Activité en retrait de la voie publique
 *Magasin
 *Fast-food
 *Supermarché
   etc. est strictement **interdite** sur ces dispositifs depuis le 13 juillet 2015. Ces genres d'activité doivent se présignaliser maintenant avec de la SIL (Signalisation d'Information Locale).